### PR TITLE
Fixes: memory leaks in eds

### DIFF
--- a/libuchardet/src/nsSBCSGroupProber.cpp
+++ b/libuchardet/src/nsSBCSGroupProber.cpp
@@ -161,7 +161,7 @@ nsProbingState nsSBCSGroupProber::HandleData(const char* aBuf, PRUint32 aLen)
     goto done;
   
   if (newLen1 == 0)
-    goto done; // Nothing to see here, move on.
+    goto cleanup; // Nothing to see here, move on.
 
   for (i = 0; i < NUM_OF_SBCS_PROBERS; i++)
   {
@@ -186,14 +186,14 @@ nsProbingState nsSBCSGroupProber::HandleData(const char* aBuf, PRUint32 aLen)
      }
   }
 
-done:
+cleanup:
 #if MAEMO_CHANGES
-  if (newLen1)
-    delete[] newBuf1;
+  delete[] newBuf1;
 #else //!MAEMO_CHANGES
   PR_FREEIF(newBuf1);
 #endif //!MAEMO_CHANGES
 
+done:
   return mState;
 }
 


### PR DESCRIPTION
There are 2 types of memory leaks
1. Memory leak in libuchardet/src/nsSBCSGroupProber.cpp - memory allocated in function is freed only if strlen > 0 (but allocated even if strlen = 0)
2. Memory leaks in addressbook/libebook-dbus/e-book.c - callbacks (responsible for freeing an argument) are called only if non-NULL but arguments are allocated everytime
